### PR TITLE
issue#6 new MockBrowser needs an option to set the document

### DIFF
--- a/lib/MockBrowser.js
+++ b/lib/MockBrowser.js
@@ -12,12 +12,20 @@ var dash = require('lodash' ),
 var MockBrowser = function(options) {
     'use strict';
 
-    var doc = jsdom('<!DOCTYPE html><html><body></body></html>' ),
-        win = doc.defaultView,
-        opts;
+    var win, opts;
 
     if (!options) {
         options = {};
+    }
+
+    if (options.window) {
+        // user has already created a jsdom window with document.
+        win = options.window;
+    }
+    else
+    {
+        var doc = jsdom('<!DOCTYPE html><html><body></body></html>' );
+        win = doc.defaultView;
     }
 
     if (!win.localStorage) {

--- a/test/MockBrowserTests.js
+++ b/test/MockBrowserTests.js
@@ -38,6 +38,14 @@ describe('MockBrowser', function() {
                 should.exist( obj );
             });
         });
+
+        it('should create a MockBrowser using user supplied window/document', function () {
+            var opts = { window: { document: 'would be a jsdom' } },
+                loadedBrowser = new MockBrowser(opts);
+
+            loadedBrowser.getWindow().should.be.equal(opts.window);
+            loadedBrowser.getDocument().should.be.equal('would be a jsdom');
+        })
     });
 
     describe('#api', function() {


### PR DESCRIPTION
Needed the ability to create a mock browser/document with file:// protocol for some app testing.
So added ability to specify a pre-loaded jsdom option when creating a new MockBrowser hope you like it.