### PR TITLE
Update jsdom and lodash dependencies

### DIFF
--- a/lib/MockBrowser.js
+++ b/lib/MockBrowser.js
@@ -5,7 +5,7 @@
  * @created: 10/8/14 6:47 PM
  */
 var dash = require('lodash' ),
-    jsdom = require('jsdom' ).jsdom,
+    JSDOM = require('jsdom' ).JSDOM,
     AbstractBrowser = require('../lib/AbstractBrowser' ),
     MockStorage = require('../lib/MockStorage');
 
@@ -24,8 +24,8 @@ var MockBrowser = function(options) {
     }
     else
     {
-        var doc = jsdom('<!DOCTYPE html><html><body></body></html>' );
-        win = doc.defaultView;
+        var doc = new JSDOM('<!DOCTYPE html><html><body></body></html>', {url: "http://localhost"});
+        win = doc.window;
     }
 
     if (!win.localStorage) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tdd"
   ],
   "dependencies": {
-    "jsdom": "^12.0.0",
+    "jsdom": "^13.0.0",
     "lodash": "^4.17"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "tdd"
   ],
   "dependencies": {
-    "jsdom": "^9.12.0",
-    "lodash": "^4.5"
+    "jsdom": "^12.0.0",
+    "lodash": "^4.17"
   },
   "devDependencies": {
     "chai": "^1.9.2",

--- a/test/AbstractBrowserTests.js
+++ b/test/AbstractBrowserTests.js
@@ -6,7 +6,7 @@
  */
 var should = require('chai').should(),
     dash = require('lodash' ),
-    jsdom = require('jsdom' ).jsdom,
+    JSDOM = require('jsdom' ).JSDOM,
     MockLogger = require('simple-node-logger' ).mocks.MockLogger,
     MockStorage = require('../lib/MockStorage' ),
     AbstractBrowser = require('../lib/AbstractBrowser');
@@ -16,8 +16,8 @@ describe('AbstractBrowser', function() {
 
     var createOptions = function() {
         var opts = {},
-            doc = jsdom('<div />' ),
-            win = doc.defaultView;
+            doc = new JSDOM('<div />', {url: "http://localhost"}),
+            win = doc.window;
 
         opts.window = win;
         opts.localStorage = new MockStorage();


### PR DESCRIPTION
* Fix security bug in lodash, as seen here: https://david-dm.org/darrylwest/mock-browser
* Update JSDOM code to match the upgraded version:
  * `url` in constructor is required to avoid `"localStorage is not available for opaque origins"` errors. Related issue: https://github.com/jsdom/jsdom/issues/2304

Fixes https://github.com/darrylwest/mock-browser/issues/18.